### PR TITLE
Browse page loading spinner + clear search button

### DIFF
--- a/CITS3403-Project/app/static/css/browse.css
+++ b/CITS3403-Project/app/static/css/browse.css
@@ -220,3 +220,31 @@ body { font-family: Arial, sans-serif; }
   margin-top: 30px;
   text-align: center;
 }
+
+/* Spinner loading */
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(0,0,0,0.1);
+  border-top-color: #2168b9;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-container {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin: 30px 0;
+}
+
+.spacing {margin-bottom: 15px}
+
+.clear-search-btn:hover {
+  border: 1px solid #3f78f5;
+}

--- a/CITS3403-Project/app/static/js/search.js
+++ b/CITS3403-Project/app/static/js/search.js
@@ -6,6 +6,8 @@ const titleInput = document.querySelector('.search-input');
 const resultsContainer = document.getElementById('book-results');
 const noMatches = document.getElementById('no-matches');
 const importBox = document.getElementById('import-box');
+const loadingIndicator = document.getElementById('loading-indicator');
+const clearSearchBtn = document.getElementById('clear-search');
 
 //Modal
 const modal = document.getElementById('modals');
@@ -26,6 +28,16 @@ sortSelect.addEventListener('change', () => {
   titleInput.dispatchEvent(new Event('input')); // re-trigger search
 });
 
+// Clear button
+clearSearchBtn.addEventListener('click', function() {
+  titleInput.value = '';
+  titleInput.focus();
+  clearSearchBtn.style.display = 'none';
+  
+  // Trigger the input event to update results
+  titleInput.dispatchEvent(new Event('input'));
+});
+
 const sortMap = {
   'relevance': '', // default
   'new': 'new',
@@ -39,10 +51,19 @@ titleInput.addEventListener('input', () => {
   const query = titleInput.value.trim();
   latestquery = query;
 
+  // Hide both messages at start of any new searches
+  noMatches.style.display = 'none';
+  importBox.style.display = 'none';
+  clearSearchBtn.style.display = query ? 'block' : 'none';
+
   if (query.length < 0) { //how much words to be typed into search bar before search results show up
     resultsContainer.innerHTML = '';
+    loadingIndicator.style.display = 'none';
     return;
   }
+
+  // Show loading indicator
+  loadingIndicator.style.display = 'flex';
 
   const fetchquery = query;
 
@@ -55,6 +76,10 @@ titleInput.addEventListener('input', () => {
   fetch(url) 
     .then(res => res.json())
     .then(data => {
+
+      // Hide loading indicator
+      loadingIndicator.style.display = 'none';
+      
       // Check if latest query matches the fetch query
       if (latestquery !== fetchquery) return;
 
@@ -112,6 +137,7 @@ titleInput.addEventListener('input', () => {
       });
     })
     .catch(err => {
+      loadingIndicator.style.display = 'none';
       console.error('Can not fetch books:', err);
       noMatches.style.display = 'none';
       importBox.style.display = 'none';

--- a/CITS3403-Project/app/templates/browse.html
+++ b/CITS3403-Project/app/templates/browse.html
@@ -14,8 +14,11 @@
 
         <div class = "top-bars">
             <!--Filter bar content-->
+            <h1 class="spacing"> Search for books </h1>
+            <p class="spacing"> Search for books via the OpenLibrary to quickly add to dashboard or click the "Add Book" to manually add one</p>
             <div class="filter-bar">
-                <input type="text" placeholder="Search all books..." class="search-input">
+                <input type="text" placeholder="Search all books by title, author or ISBN..." class="search-input">
+                <button id="clear-search" class="clear-search-btn" style="display: none;">&times;</button>
                 <div class="custom-select-wrapper">
                     <select id = "sort-select">
                         <option value="relevance">Relevance</option>
@@ -26,6 +29,12 @@
             </div>
             <a href="{{ url_for('main.uploadbook') }}"><button class ="add-book-btn"> Add book</button></a>
             <p id = "no-matches" style = "display: none;"><span class="no-match-text">No matches.</span></p>
+        </div>
+
+        <!--Spinning loading-->
+        <div class="loading-container" id="loading-indicator" style="display: none;">
+            <div class="spinner"></div>
+            <p>Fetching books...</p>
         </div>
     
         <div class="book-list" id="book-results">

--- a/CITS3403-Project/app/templates/browse.html
+++ b/CITS3403-Project/app/templates/browse.html
@@ -15,7 +15,9 @@
         <div class = "top-bars">
             <!--Filter bar content-->
             <h1 class="spacing"> Search for books </h1>
-            <p class="spacing"> Search for books via the OpenLibrary to quickly add to dashboard or click the "Add Book" to manually add one</p>
+            <p class="spacing"> Search the OpenLibrary database to quickly add to dashboard or click the 
+                <a href="{{ url_for('main.uploadbook') }}" class="text-link">"Add Book"</a> 
+                 button to manually add titles to your collection</p>
             <div class="filter-bar">
                 <input type="text" placeholder="Search all books by title, author or ISBN..." class="search-input">
                 <button id="clear-search" class="clear-search-btn" style="display: none;">&times;</button>


### PR DESCRIPTION
- Just very minor additions to the browse page ui

- Browse page spinner when you search something via API, while it loads, a spinner will show
<img width="1032" alt="Screenshot 2025-05-16 at 5 47 54 PM" src="https://github.com/user-attachments/assets/8213603e-b01b-4fd2-8758-1d55b15d440e" />

- When you enter something in the search bar, a clear search button will appear for you to clear the search bar
<img width="1065" alt="Screenshot 2025-05-16 at 6 08 31 PM" src="https://github.com/user-attachments/assets/19f9c03f-ef75-4d40-9ef7-e536e2ba5a13" />

- Blurb added to make it clearer for the users about being able to search for books via open library vs manually adding book via add book button (was bit confusing what the add book button was)


