### PR TITLE
Move the functionality of the email reset to the init.py

### DIFF
--- a/CITS3403-Project/app/__init__.py
+++ b/CITS3403-Project/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_migrate import Migrate
 from flask_mail import Mail
 from app.config import Config
+import os
 
 mail = Mail()
 
@@ -30,6 +31,49 @@ def create_app():
         db.create_all()
 
     return app
+def ensure_email_env_vars():
+    # Get the path to the .env file in the project root directory
+    env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
+
+    # Define email-related environment variables
+    email_vars = {
+        'MAIL_SERVER': 'smtp.gmail.com',
+        'MAIL_PORT': '587',
+        'MAIL_USE_TLS': 'True',
+        'MAIL_USE_SSL': 'False',
+        'MAIL_USERNAME': 'booktracker00@gmail.com',
+        'MAIL_PASSWORD': 'rhlw kjwh purj ihqe',
+        'MAIL_DEFAULT_SENDER': 'booktracker00@gmail.com'
+    }
+
+    # Read existing .env file lines
+    existing_lines = []
+    if os.path.exists(env_path):
+        with open(env_path, 'r') as f:
+            existing_lines = f.readlines()
+
+    # Create a set of existing environment variable names
+    existing_vars = {line.split('=')[0].strip() for line in existing_lines if '=' in line}
+
+    # Prepare new variables to be added
+    to_add = []
+    for var, val in email_vars.items():
+        # Only add variables that don't already exist
+        if var not in existing_vars:
+            to_add.append(f"{var}={val}\n")
+
+    # Append new variables to the .env file
+    if to_add:
+        with open(env_path, 'a') as f:
+            # Ensure we start on a new line
+            if existing_lines and not existing_lines[-1].endswith('\n'):
+                f.write('\n')
+
+            # Write new environment variables
+            f.writelines(to_add)
+
+ensure_email_env_vars()
+
 
 # Create the application instance
 app = create_app()

--- a/README.md
+++ b/README.md
@@ -50,16 +50,7 @@ In the root directory, create a file named **.env** and in it define the session
 ```
 SECRET_KEY=somelongandsecurekey123
 ```
-Also in the **.env** file, you need to put following code to let the reset password function worked
-```
-MAIL_SERVER=smtp.gmail.com
-MAIL_PORT=587
-MAIL_USE_TLS=True
-MAIL_USE_SSL=False
-MAIL_USERNAME=booktracker00@gmail.com
-MAIL_PASSWORD=rhlw kjwh purj ihqe
-MAIL_DEFAULT_SENDER=booktracker00@gmail.com
-```
+
 
 ## Automated Testing
 


### PR DESCRIPTION
Move the functionality of the email reset to the init.py to make it more clearly and delete the tips in the README file